### PR TITLE
requirements.txt versions, gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,178 @@
-# Ignore the entire PPMI folder and all its contents:
+# Ignore the entire PPMI and data folder and all their contents:
 PPMI/
+data/
 
-# Python packaging files
-*.egg-info/
+# Byte-compiled / optimized / DLL files
 __pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
 build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ Parkinson's Insight Engine (PIE) is a Python-based data preprocessing and analys
 
 ## Getting Started
 
+Clone this repository to your local machine:
+
+```bash
+git clone https://github.com/MJFF-ResearchCommunity/PIE.git
+cd PIE
+```
+
 ### Prerequisites
 To use PIE, please ensure you have installed Python 3.8 or later. The pipeline relies on the following libraries:
 
@@ -34,12 +41,6 @@ pip install -r requirements.txt
 ```
 
 ### Installation
-Clone this repository to your local machine:
-
-```bash
-git clone https://github.com/MJFF-ResearchCommunity/PIE.git
-cd PIE
-```
 
 Install the package:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-matplotlib>=3.10.1
-numpy>=2.2.3
-pandas>=2.2.3
-plotly>=6.0.0
-pytest>=7.1.1
-scikit-learn>=1.6.1
-seaborn>=0.13.2
-xgboost>=2.1.4
+matplotlib>=3.4.3
+numpy>=1.21.2
+pandas>=1.3.3
+plotly>=5.3.1
+pytest>=6.2.5
+scikit-learn>=0.24.2
+seaborn>=0.11.2
+xgboost>=1.4.2


### PR DESCRIPTION
- added more to .gitignore [from the python template here ](https://github.com/github/gitignore/blob/main/Python.gitignore)while keeping PPMI/ and data/ folders
- changed README.md - clone repo before running requirements.txt
- updated versions in requirements.txt to more stable versions that should be compatible with python 3.8 and above (tested on python 3.9.6)

checked to make sure `pytests tests` ran successfully before making the request.