### PR TITLE
Add logger and tidy up README contribution instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Visualizer.plot_distribution(selected_features, column="age")
 ```
 
 ### Example Notebook
-Explore the example Jupyter notebook (`examples/pipeline_demo.ipynb`) to see PIE in action.
+Explore the example Jupyter notebooks (eg `notebooks/pipeline_demo.ipynb`) to see PIE in action.
 
 ## Repository Structure
 ```plaintext
@@ -117,9 +117,9 @@ PIE/
 │   ├── data_loader.py    # Module for loading data
 │   ├── data_preprocessor.py # Module for cleaning data
 │   ├── feature_engineer.py  # Module for feature engineering
-│   ├── feature_selector.py     # Module for feature selection
+│   ├── feature_selector.py  # Module for feature selection
 │   ├── visualizer.py        # Module for data visualization
-├── examples/            # Example Jupyter notebooks
+├── notebooks/           # Example Jupyter notebooks
 ├── tests/               # Unit tests
 ├── PPMI/                # Local copies of the PPMI data files
 ├── requirements.txt     # List of dependencies
@@ -131,9 +131,11 @@ PIE/
 Contributions are welcome! To contribute:
 1. Fork the repository.
 2. Create a new branch for your feature: `git checkout -b feature-name`.
-3. Commit your changes: `git commit -m 'Add new feature'`.
-4. Push to the branch: `git push origin feature-name`.
-5. Create a pull request.
+3. Copy the PPMI data into the `PIE/PPMI` directory.
+4. Instead of installing PIE as above, use `pip install -e .` for editable mode.
+5. Commit your changes: `git commit -m 'Add new feature'`.
+6. Push to the branch: `git push origin feature-name`.
+7. Create a pull request.
 
 ### Running Tests
 Ensure all tests pass before submitting a pull request:

--- a/pie/__init__.py
+++ b/pie/__init__.py
@@ -1,0 +1,9 @@
+import logging
+import sys
+
+logger = logging.getLogger("PIE")
+logger.setLevel(logging.INFO)
+ch = logging.StreamHandler(sys.stdout)
+ch.setFormatter(logging.Formatter("%(asctime)s %(filename)s [%(levelname)s] %(message)s",
+                                  datefmt="%Y-%m-%d %H:%M:%S"))
+logger.addHandler(ch)

--- a/pie/feature_engineer.py
+++ b/pie/feature_engineer.py
@@ -4,7 +4,10 @@ feature_engineer.py
 Methods for feature engineering, such as aggregation or derived features.
 """
 
+import logging
 import pandas as pd
+
+logger = logging.getLogger(f"PIE.{__name__}")
 
 class FeatureEngineer:
     """
@@ -20,5 +23,5 @@ class FeatureEngineer:
         :return: Data with engineered features.
         """
         # TODO: Implement feature engineering logic.
-        print("FeatureEngineer.create_features() is just a placeholder.")
-        return data_dict 
+        logger.info("FeatureEngineer.create_features() is just a placeholder.")
+        return data_dict

--- a/pie/feature_selector.py
+++ b/pie/feature_selector.py
@@ -4,7 +4,10 @@ feature_selector.py
 Methods for selecting the most relevant features from the dataset.
 """
 
+import logging
 import pandas as pd
+
+logger = logging.getLogger(f"PIE.{__name__}")
 
 class FeatureSelector:
     """
@@ -21,5 +24,5 @@ class FeatureSelector:
         :return: DataFrame with only selected features (and target).
         """
         # TODO: Implement feature selection logic.
-        print("FeatureSelector.select_features() is just a placeholder.")
-        return data 
+        logger.info("FeatureSelector.select_features() is just a placeholder.")
+        return data

--- a/pie/med_hist_loader.py
+++ b/pie/med_hist_loader.py
@@ -1,7 +1,10 @@
+import logging
 import glob
 import os
 import pandas as pd
 import numpy as np
+
+logger = logging.getLogger(f"PIE.{__name__}")
 
 # Many medical history files cannot be merged, because data is recorded multiple times per visit,
 # or on a timeline that doesn't correspond to the visits. Examples of the first are Adverse Event
@@ -130,7 +133,7 @@ def load_ppmi_medical_history(folder_path: str) -> pd.DataFrame:
         # Strip directory path, and look only at the filename for the prefix
         matching_files = [f for f in all_csv_files if f.split("/")[-1].startswith(prefix)]
         if not matching_files:
-            print(f"[ERROR] No CSV file found for prefix: {prefix}")
+            logger.warning(f"No CSV file found for prefix: {prefix}")
             continue
 
         for filename in matching_files:
@@ -139,7 +142,7 @@ def load_ppmi_medical_history(folder_path: str) -> pd.DataFrame:
                 df_temp = pd.read_csv(csv_file)
                 found_any_file = True
             except Exception as e:
-                print(f"[ERROR] Could not read file '{csv_file}': {e}")
+                logger.warning(f"Could not read file '{csv_file}': {e}")
                 continue
 
             # 1) Rename any leftover _x / _y columns in df_temp
@@ -149,7 +152,7 @@ def load_ppmi_medical_history(folder_path: str) -> pd.DataFrame:
 
     # Return empty DataFrame if no data was loaded
     if not found_any_file:
-        print("[WARNING] No matching medical history CSV files were loaded - returning empty dict.")
+        logger.warning("No matching medical history CSV files were loaded - returning empty dict.")
 
     return df_dict
 
@@ -157,6 +160,6 @@ def load_ppmi_medical_history(folder_path: str) -> pd.DataFrame:
 def main():
     path_to_med_history = "./PPMI/Medical_History"
     med_history = load_ppmi_medical_history(path_to_med_history)
-    print(sorted(list(med_history.keys())))
+    logger.info(sorted(list(med_history.keys())))
 if __name__ == "__main__":
     main()

--- a/pie/sub_char_loader.py
+++ b/pie/sub_char_loader.py
@@ -1,7 +1,10 @@
 import glob
+import logging
 import os
 import pandas as pd
 import numpy as np
+
+logger = logging.getLogger(f"PIE.{__name__}")
 
 FILE_PREFIXES = [
     "Age_at_visit",
@@ -95,7 +98,7 @@ def load_ppmi_subject_characteristics(folder_path: str) -> pd.DataFrame:
         # Gather all files that start with the prefix (filename only; strip directory path)
         matching_files = [f for f in all_csv_files if f.split("/")[-1].startswith(prefix)]
         if not matching_files:
-            print(f"[ERROR] No CSV file found for prefix: {prefix}")
+            logger.warning(f"No CSV file found for prefix: {prefix}")
             continue
         for filename in matching_files:
             csv_file = os.path.join(folder_path, filename)
@@ -103,7 +106,7 @@ def load_ppmi_subject_characteristics(folder_path: str) -> pd.DataFrame:
                 df_temp = pd.read_csv(csv_file)
                 found_any_file = True
             except Exception as e:
-                print(f"[ERROR] Could not read file '{csv_file}': {e}")
+                logger.error(f"Could not read file '{csv_file}': {e}")
                 continue
             # If df_merged is empty, just set df_merged = df_temp
             if df_merged is None:
@@ -118,7 +121,7 @@ def load_ppmi_subject_characteristics(folder_path: str) -> pd.DataFrame:
                 df_merged = pd.merge(df_merged, df_temp, on=merge_keys, how="outer")
     # If nothing loaded successfully, return empty DataFrame
     if not found_any_file or df_merged is None:
-        print("[WARNING] No matching CSV files were successfully loaded. Returning empty DataFrame.")
+        logger.warning("No matching CSV files were successfully loaded. Returning empty DataFrame.")
         return pd.DataFrame()
     columns_to_deduplicate = ["PAG_NAME","INFODT","ORIG_ENTRY","LAST_UPDATE","COHORT","REC_ID"]
     # Deduplicate the columns
@@ -134,7 +137,7 @@ def main():
     """
     path_to_subject_characteristics = "./PPMI/_Subject_Characteristics"
     df_subjects = load_ppmi_subject_characteristics(path_to_subject_characteristics)
-    print(df_subjects.head(25))  # Show first rows to see merge results
+    logger.info(df_subjects.head(25))  # Show first rows to see merge results
     df_subjects.to_csv("subject_characteristics.csv", index=False)
 
 if __name__ == "__main__":

--- a/pie/visualizer.py
+++ b/pie/visualizer.py
@@ -4,9 +4,12 @@ visualizer.py
 Methods for generating visualizations of data and results.
 """
 
+import logging
 import pandas as pd
 import matplotlib.pyplot as plt
 import seaborn as sns
+
+logger = logging.getLogger(f"PIE.{__name__}")
 
 class Visualizer:
     """
@@ -22,4 +25,4 @@ class Visualizer:
         :param column: The name of the column to visualize.
         """
         # TODO: Implement actual plotting logic.
-        print(f"Visualizer.plot_distribution() is a placeholder for column '{column}'.") 
+        logger.info(f"Visualizer.plot_distribution() is a placeholder for column '{column}'.")


### PR DESCRIPTION
The only change in functionality is to use a Python logger instead of print statements to log to `stdout`. There is a cascading logger hierarchy with a parent named `PIE`, and each file creates a child logger named `f"PIE.{__name__}"`.

An example of the log format is:
```
2025-03-14 15:00:37 med_hist_loader.py [WARNING] No CSV file found for prefix: Tau_Substudy
2025-03-14 15:00:37 data_preprocessor.py [INFO] There are 78 concomitant medication entries with no start date.
2025-03-14 15:00:37 data_preprocessor.py [INFO] There are 21696 concomitant medication entries with no stop date.
```